### PR TITLE
[이진우] 카드 생성자 닉네임 기록을 위한 card table col 추가 & 누락 api 명세(point) 추가

### DIFF
--- a/docs/api_point.md
+++ b/docs/api_point.md
@@ -1,26 +1,55 @@
-## api template
+## POST /points/box
 
 ### req template
 
-- description :
-- path :
-- type :
+- description : 랜덤 포인트(1~3) 추가. API 호출 시 랜덤으로 1~3의 포인트를 추가(호출 시간 기록 - 1시간에 한번만 호출되도록 userId와 같이 기록)
+- path : /points/box
+- type : POST
 - header
-  - property1 :
-  - property2 :
-- body
-  - property1 :
-  - property2 :
+  - Authorization : Bearer {accessToken}
 
 ### req example
 
-- header :
-- body :
+- header
+  - Authorization : Bearer {accessToken}
 
 ### res template
 
-- data :
+- data : {
+  earnedPoint : 획득한 포인트,
+  point : 사용자 포인트
+  }
 
 ### res example
 
-- data :
+- data : {
+  earnedPoint : 2,
+  point : 14
+  }
+
+## GET /points/last-box-time
+
+### req template
+
+- description : 마지막으로 호출한 POST /point/box 시간 차이 확인
+- path : /points/last-box-time-gap
+- type : GET
+- header
+  - Authorization : Bearer {accessToken}
+
+### req example
+
+- header
+  - Authorization : Bearer {accessToken}
+
+### res template
+
+- data : {
+  time-gap : 시간 단위로 버림된 값을 전달(int로 전달)
+  }
+
+### res example
+
+- data : {
+  time-gap : 2
+  }

--- a/docs/api_user.md
+++ b/docs/api_user.md
@@ -35,7 +35,7 @@
       - genre : 카드 장르 (int로 전달)
       - ownCount : 카드 보유량
       - price : 카드 가격(포인트)
-      - sellerNickname : 판매자 닉네임
+      - authorNickname : 카드 생성자 닉네임
 
 ### res example
 
@@ -48,7 +48,7 @@
   genre : 2,
   ownCount : 2,
   price : 4,
-  sellerNickname : 프로여행러
+  authorNickname : 프로여행러
   },
   {
   ...
@@ -87,7 +87,7 @@
   genre : 2,
   count : 2,
   price : 4,
-}
+  }
 
 ### res template
 
@@ -100,7 +100,7 @@
   - genre : 카드 장르 (int로 전달)
   - totalQuantity : 카드 생성 갯수
   - price : 카드 가격(초기 포인트 : 판매 포인트와 별도. 교환 신청에서 사용됨)
-
+  - authorNickname : 카드 생성자 닉네임
 
 ### res example
 
@@ -111,7 +111,8 @@
   genre : 2,
   count : 2,
   price : 4,
-}
+  authorNickname : 코드잇
+  }
 
 ## GET /users/my-cards/shop
 
@@ -150,7 +151,7 @@
       - genre : 카드 장르 (int로 전달)
       - ownCount : 카드 보유량
       - price : 카드 가격(포인트)
-      - sellerNickname : 판매자 닉네임
+      - authorNickname : 카드 생성자 닉네임
 
 ### res example
 
@@ -163,7 +164,7 @@
   genre : 2,
   ownCount : 2,
   price : 4,
-  sellerNickname : 프로여행러
+  authorNickname : 프로여행러
   },
   {
   ...
@@ -209,7 +210,7 @@
       - genre : 카드 장르 (int로 전달)
       - ownCount : 카드 보유량
       - price : 카드 가격(포인트)
-      - sellerNickname : 판매자 닉네임
+      - authorNickname : 카드 생성자 닉네임
 
 ### res example
 
@@ -222,7 +223,7 @@
   genre : 2,
   ownCount : 2,
   price : 4,
-  sellerNickname : 프로여행러
+  authorNickname : 프로여행러
   },
   {
   ...
@@ -246,18 +247,17 @@
 - header :
   - Authorization : Bearer {accessToken}
 
-
 ### res template
 
 - data : {
   nickname : 닉네임
-}
+  }
 
 ### res example
 
 - data : {
   nickname : 코드잇16
-}
+  }
 
 ## GET /users/check-email
 
@@ -274,18 +274,17 @@
 - header :
   - Authorization : Bearer {accessToken}
 
-
 ### res template
 
 - data : {
   isPossible : 사용 가능 여부(bool)
-}
+  }
 
 ### res example
 
 - data : {
   isPossible : true
-}
+  }
 
 ## GET /users/check-nickname
 
@@ -306,12 +305,10 @@
 
 - data : {
   isPossible : 사용 가능 여부(bool)
-}
-
+  }
 
 ### res example
 
 - data : {
   isPossible : true
-}
-
+  }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -29,6 +29,7 @@ model User {
   Exchanges     Exchange[]
   Notifications Notification[]
   LastBoxTime   LastBoxTime[]
+  Card          Card[]
 
   @@map("user")
 }
@@ -41,6 +42,8 @@ model Card {
   grade         Int
   genre         Int
   image         String   @db.VarChar(2048)
+  User          User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId        String   @map("user_id") @db.VarChar(36)
   totalQuantity Int      @map("total_quantity")
   createdAt     DateTime @default(now()) @map("created_at")
   updatedAt     DateTime @updatedAt @map("updated_at")

--- a/src/constants/error.js
+++ b/src/constants/error.js
@@ -1,7 +1,7 @@
 // 사용 여부 보류
 // errorHandler에서 err 정보를 추가한 error message 처리 중
 
-export const CUSTOM_ERRORS = {
+export const CUSTOM_ERRORS_CODE = {
   401: "Unauthorized",
   409: "Unique constraint failed on the field",
   404: "Not Found",


### PR DESCRIPTION
## #️⃣연관된 이슈

> 카드 닉네임/가격 노출

## 📝작업 내용

>  카드 생성자 닉네임 기록을 위한 card table col(userId) 추가
> 누락 api 명세(point) 추가

### 스크린샷
![image](https://github.com/user-attachments/assets/7b0baf62-b801-4701-bfdd-35b737735b5f)

## 💬리뷰 요구사항(선택)

> DB 추가된 col 확인
> 혹시 리뷰어가 작성중인 API의 경로가 /users, /points 처럼 복수형으로 시작하지 않는지 확인 요망
