### PR TITLE
[이진우] 보유한 카드 상세 조회 API 추가

### DIFF
--- a/docs/api_user.md
+++ b/docs/api_user.md
@@ -2,7 +2,7 @@
 
 ### req template
 
-- description : 구매한 포토 카드 조회 (정렬 / 필터 / 키워드 / 페이지네이션)
+- description : 구매한 포토 카드 목록 조회 (정렬 / 필터 / 키워드 / 페이지네이션)
 - path : /users/my-cards
 - method : GET
 - query
@@ -55,6 +55,48 @@
   "quantity": 8
   }
   ]
+  }
+
+## GET /users/my-cards/:cardId
+
+### req template
+
+- description : 보유한 포토 카드 조회 (정렬 / 필터 / 키워드 / 페이지네이션)
+- path : /users/my-cards
+- method : GET
+- param
+  - cardId : 카드 id
+
+### req example
+
+- param
+  c618558f-f82a-456e-bb98-62084afc7954
+
+### res template
+
+- data
+  - id : 카드 id
+  - image : 카드 이미지 url (max-length : 2048)
+  - name : 카드 이름 (max-length 50)
+  - grade : 카드 등급 (int로 전달)
+  - genre : 카드 장르 (int로 전달)
+  - price : 카드 가격(초기 포인트 : 판매 포인트와 별도. 교환 신청에서 사용됨)
+  - nickname : 카드 생성자 닉네임
+  - description : 카드 설명 (max-length 1024)
+  - quantity : 카드 생성 갯수
+
+### res example
+
+- data : {
+  "id": "c618558f-f82a-456e-bb98-62084afc7954",
+  "image": "https://cdn.pixabay.com/photo/2024/09/07/02/34/penguins-9028827_640.jpg",
+  "name": "낮 펭귄",
+  "grade": 3,
+  "genre": 2,
+  "price": 4,
+  "nickname": "코드잇05",
+  "description": "동물 펭귄01",
+  "quantity": 7
   }
 
 ## POST /users/my-cards

--- a/http/users.http
+++ b/http/users.http
@@ -1,5 +1,5 @@
 ###
-GET http://localhost:3000/users/my-cards
+GET http://localhost:3000/users/my-cards/c618558f-f82a-456e-bb98-62084afc7954
 Content-Type : application/json
 Cookie: connect.sid=YOUR_SESSION_COOKIE_HERE
 
@@ -83,8 +83,8 @@ POST http://localhost:3000/auth/sign-in
 Content-Type : application/json
 
 {
-    "email" : "codeit05@codeit.com",
-    "password" : "!codeit05"
+    "email" : "codeit04@codeit.com",
+    "password" : "!codeit04"
 }
 
 ###

--- a/src/controllers/users-controller.js
+++ b/src/controllers/users-controller.js
@@ -12,6 +12,18 @@ async function getMyCardList(req, res, next) {
   }
 }
 
+async function getMyCard(req, res, next) {
+  try {
+    const { cardId } = req.params;
+    const userId = req.session.userId;
+    const result = await userService.getMyCard({ userId, cardId });
+
+    return res.status(200).send(result);
+  } catch (err) {
+    return next(err);
+  }
+}
+
 async function createMyCard(req, res, next) {
   try {
     const { name, description, image, grade, genre, price, quantity } =
@@ -87,6 +99,7 @@ async function getMyRequestList(req, res, next) {
 
 export default {
   getMyCardList,
+  getMyCard,
   createMyCard,
   getMyShopList,
   getMyRequestList,

--- a/src/middlewares/auth.js
+++ b/src/middlewares/auth.js
@@ -1,5 +1,6 @@
 import { createCustomError } from "../lib/custom-error.js";
 import shopRepository from "../repositories/shopRepository.js";
+import ownRepository from "../repositories/ownRepository.js";
 
 export function authMiddleware(req, res, next) {
   if (req.session && req.session.userId) {
@@ -20,6 +21,27 @@ export async function authMiddlewareByShopIdParam(req, res, next) {
     const shop = await shopRepository.findShopOwnerId(shopId);
 
     if (shop.User.id === req.session.userId) {
+      return next();
+    }
+
+    return next(createCustomError(401));
+  } catch (err) {
+    return next(err);
+  }
+}
+
+export async function authMiddlewareByCardIdParam(req, res, next) {
+  const { cardId } = req.params;
+  const userId = req.session.userId;
+
+  if (!cardId) {
+    return next(createCustomError(400));
+  }
+
+  try {
+    const own = await ownRepository.findShopOwnerId({ userId, cardId });
+
+    if (own) {
       return next();
     }
 

--- a/src/repositories/ownRepository.js
+++ b/src/repositories/ownRepository.js
@@ -37,6 +37,16 @@ async function findOwnCardList({ userId, filter }) {
   });
 }
 
+async function findOwnCard({ userId, cardId }) {
+  return await prisma.own.findFirst({
+    where: {
+      userId,
+      cardId,
+    },
+    select: ownCardSelect,
+  });
+}
+
 async function getGroupCountByGrade({ userId, filter }) {
   const { where } = filter;
 
@@ -95,12 +105,21 @@ async function addQuantity({ userId, cardId, increment }) {
   });
 }
 
+async function findShopOwnerId({ userId, cardId }) {
+  return prisma.own.findFirst({
+    where: { userId, cardId },
+    select: ownCardSelect,
+  });
+}
+
 export default {
   getByFilter,
   update,
   createOwn,
   findOwnCardList,
+  findOwnCard,
   getGroupCountByGrade,
   deleteById,
   addQuantity,
+  findShopOwnerId,
 };

--- a/src/routes/user-router.js
+++ b/src/routes/user-router.js
@@ -1,12 +1,21 @@
 import express from "express";
 
 import userController from "../controllers/users-controller.js";
-import { authMiddleware } from "../middlewares/auth.js";
+import {
+  authMiddleware,
+  authMiddlewareByCardIdParam,
+} from "../middlewares/auth.js";
 
 const userRouter = express.Router();
 
 userRouter
   .get("/my-cards", authMiddleware, userController.getMyCardList)
+  .get(
+    "/my-cards/:cardId",
+    authMiddleware,
+    authMiddlewareByCardIdParam,
+    userController.getMyCard
+  )
   .post("/my-cards", authMiddleware, userController.createMyCard)
   .get("/my-cards/shop", authMiddleware, userController.getMyShopList)
   .get("/my-cards/exchange", authMiddleware, userController.getMyRequestList)

--- a/src/services/user-service.js
+++ b/src/services/user-service.js
@@ -22,6 +22,12 @@ async function getMyCardList({ userId, query }) {
   return myCardListMapper({ counts, list });
 }
 
+async function getMyCard({ userId, cardId }) {
+  const result = await ownRepository.findOwnCard({ userId, cardId });
+
+  return myCardMapper(result);
+}
+
 async function createMyCard({
   name,
   description,
@@ -75,4 +81,10 @@ async function getMyRequestList({ userId, query }) {
   return myExchangeListMapper({ counts, list });
 }
 
-export default { getMyCardList, createMyCard, getMyShopList, getMyRequestList };
+export default {
+  getMyCardList,
+  getMyCard,
+  createMyCard,
+  getMyShopList,
+  getMyRequestList,
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

> 보유한 카드 상세 페이지에서 필요한 API 추가

## 📝작업 내용

> cardId를 이용해, 자신이 보유한 카드 상세 정보 제공
> 보유한 카드만 조회 가

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/28a99da5-d617-4be4-9e89-8d1ab38d6c31)

## 💬리뷰 요구사항(선택)

> 기존의 기능을 이용해 구현했고, cardId를 기준으로 보유 여부를 판단하는 미들웨어를 추가했습니다
