### PR TITLE
[이진우] 세션 인증 설정 수정 && 사용자 정보 조회 API 추가

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,8 @@
+DATABASE_URL="postgresql://favorite_photo_user:qsu0OxrA79Vhgdj2BazMMLLpRIdBtFsy@dpg-cs7gi4rv2p9s73f28rr0-a.singapore-postgres.render.com/favorite_photo"
+PORT=3000
+GOOGLE_APPLICATION_CREDENTIALS="C:\Users\SnowRang\Downloads\imageupload-438323-ec84d83001b5.json"
+SESSION_SECRET="code-it-session-secret"
+AWS_ACCESS_KEY_ID="young-has"
+AWS_SECRET_ACCESS_KEY="young-has"
+SESSION_SECURE="false"
+SESSION_SAMESITE="lax"

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,8 @@
+DATABASE_URL="postgresql://favorite_photo_user:qsu0OxrA79Vhgdj2BazMMLLpRIdBtFsy@dpg-cs7gi4rv2p9s73f28rr0-a.singapore-postgres.render.com/favorite_photo"
+PORT=3000
+GOOGLE_APPLICATION_CREDENTIALS="C:\Users\SnowRang\Downloads\imageupload-438323-ec84d83001b5.json"
+SESSION_SECRET="code-it-session-secret"
+AWS_ACCESS_KEY_ID="young-has"
+AWS_SECRET_ACCESS_KEY="young-has"
+SESSION_SECURE="true"
+SESSION_SAMESITE="none"

--- a/app.js
+++ b/app.js
@@ -37,7 +37,7 @@ app.use(
     cookie: {
       httpOnly: true,
       secure: false,
-      sameSite: "none",
+      sameSite: "lax",
       maxAge: EXPIRE_TIME,
     },
   })

--- a/app.js
+++ b/app.js
@@ -37,7 +37,7 @@ app.use(
     cookie: {
       httpOnly: true,
       secure: false,
-      sameSite: "lax",
+      sameSite: "none",
       maxAge: EXPIRE_TIME,
     },
   })

--- a/app.js
+++ b/app.js
@@ -36,7 +36,7 @@ app.use(
     rolling: true,
     cookie: {
       httpOnly: true,
-      secure: true,
+      secure: false,
       sameSite: "none",
       maxAge: EXPIRE_TIME,
     },

--- a/app.js
+++ b/app.js
@@ -36,7 +36,7 @@ app.use(
     rolling: true,
     cookie: {
       httpOnly: true,
-      secure: false,
+      secure: true,
       sameSite: "none",
       maxAge: EXPIRE_TIME,
     },

--- a/app.js
+++ b/app.js
@@ -37,7 +37,7 @@ app.use(
     cookie: {
       httpOnly: true,
       secure: false, // 개발용
-      sameSite: "lax", // 개발용
+      sameSite: "none", // 개발용
       maxAge: EXPIRE_TIME,
     },
   })

--- a/app.js
+++ b/app.js
@@ -24,10 +24,7 @@ export const app = express();
 
 app.use(
   cors({
-    origin: [
-      "http://localhost:3000",
-      "https://one-favoritephoto-1-be.onrender.com",
-    ],
+    origin: "http://localhost:3000",
     methods: ["GET", "POST", "PUT", "DELETE"],
     credentials: true,
   })
@@ -40,8 +37,10 @@ app.use(
     rolling: true,
     cookie: {
       httpOnly: true,
-      secure: true,
-      sameSite: "none",
+      // secure: true,
+      secure: false,
+      // sameSite: "none",
+      sameSite: "lax",
       maxAge: EXPIRE_TIME,
     },
   })

--- a/app.js
+++ b/app.js
@@ -24,7 +24,11 @@ export const app = express();
 
 app.use(
   cors({
-    origin: "http://localhost:3000",
+    origin: [
+      "http://localhost:3000",
+      "https://one-favoritephoto-1-be.onrender.com",
+    ],
+    methods: ["GET", "POST", "PUT", "DELETE"],
     credentials: true,
   })
 );

--- a/app.js
+++ b/app.js
@@ -1,6 +1,5 @@
 import cors from "cors";
 import express from "express";
-import dotenv from "dotenv";
 import session from "express-session";
 
 import adminRouter from "./src/controllers/admin-controller.js";
@@ -18,29 +17,32 @@ import {
 } from "./src/middlewares/error.js";
 
 import { EXPIRE_TIME } from "./src/constants/session.js";
+import {
+  SESSION_SECRET,
+  SESSION_SECURE,
+  SESSION_SAMESITE,
+  PORT,
+} from "./config.js";
 
-dotenv.config();
 export const app = express();
 
 app.use(
   cors({
     origin: "http://localhost:3000",
-    methods: ["GET", "POST", "PUT", "DELETE"],
     credentials: true,
   })
 );
+app.set("trust proxy", 1);
 app.use(
   session({
-    secret: process.env.SESSION_SECRET,
+    secret: SESSION_SECRET,
     resave: false,
     saveUninitialized: false,
     rolling: true,
     cookie: {
       httpOnly: true,
-      // secure: true,
-      secure: false,
-      // sameSite: "none",
-      sameSite: "lax",
+      secure: SESSION_SECURE,
+      sameSite: SESSION_SAMESITE,
       maxAge: EXPIRE_TIME,
     },
   })
@@ -60,4 +62,4 @@ app.use(logErrors);
 app.use(clientErrorHandler);
 app.use(serverErrorHandler);
 
-app.listen(3000, () => console.log("Server is listening"));
+app.listen(PORT, () => console.log(`Server is listening port : ${PORT}`));

--- a/app.js
+++ b/app.js
@@ -37,7 +37,7 @@ app.use(
     cookie: {
       httpOnly: true,
       secure: false, // 개발용
-      sameSite: "none", // 개발용
+      sameSite: "lax", // 개발용
       maxAge: EXPIRE_TIME,
     },
   })

--- a/app.js
+++ b/app.js
@@ -36,8 +36,8 @@ app.use(
     rolling: true,
     cookie: {
       httpOnly: true,
-      secure: false, // 개발용
-      sameSite: "lax", // 개발용
+      secure: true,
+      sameSite: "none",
       maxAge: EXPIRE_TIME,
     },
   })

--- a/config.js
+++ b/config.js
@@ -1,0 +1,7 @@
+import { config } from "./env.js";
+
+export const DATABASE_URL = config.DATABASE_URL;
+export const PORT = config.PORT;
+export const SESSION_SECRET = config.SESSION_SECRET;
+export const SESSION_SECURE = config.SESSION_SECURE;
+export const SESSION_SAMESITE = config.SESSION_SAMESITE;

--- a/docs/api_user.md
+++ b/docs/api_user.md
@@ -284,31 +284,33 @@
   ]
   }
 
-## GET /users/profile
+## GET /users/my-info
 
 ### req template
 
-- description : 사용자 프로필(닉네임) 조회
-- path : /users/profile
+- description : 사용자 정보 조회 : point 확인용
+- path : /users/my-info
 - method : GET
-- headers :
-  - Authorization : Bearer {accessToken}
 
 ### req example
 
-- headers :
-  - Authorization : Bearer {accessToken}
-
 ### res template
 
-- data : {
-  nickname : 닉네임
-  }
+- data
+  - id : 사용자 아이디(FE에서 필요없다면 삭제 예정)
+  - email : 사용자 이메일
+  - nickname : 사용자 닉네임
+  - point : 사용자 포인트
+  - createdAt : 아이디 생성 시간
 
 ### res example
 
 - data : {
-  nickname : 코드잇16
+  "id": "fe192f26-7afa-4b85-a6f8-5dc8469a8aee",
+  "email": "codeit06@codeit.com",
+  "nickname": "코드잇06",
+  "point": 0,
+  "createdAt": "2024-10-17T01:19:58.198Z"
   }
 
 ## GET /users/check-email

--- a/env.js
+++ b/env.js
@@ -1,0 +1,17 @@
+import dotenv from "dotenv";
+import path from "path";
+
+const NODE_ENV = process.env.NODE_ENV || "production";
+const envFilePath = path.resolve(`./.env.${NODE_ENV}`).trim();
+
+dotenv.config({ path: envFilePath });
+
+export const config = {
+  DATABASE_URL: process.env.DATABASE_URL,
+  PORT: process.env.PORT,
+  SESSION_SECRET: process.env.SESSION_SECRET,
+  SESSION_SECURE: process.env.SESSION_SECURE
+    ? JSON.parse(process.env.SESSION_SECURE.toLowerCase())
+    : false,
+  SESSION_SAMESITE: process.env.SESSION_SAMESITE,
+};

--- a/http/users.http
+++ b/http/users.http
@@ -117,9 +117,11 @@ POST https://one-favoritephoto-1-be.onrender.com/auth/sign-in
 Content-Type : application/json
 
 {
-  "email" : "codeit05@codeit.com",
-  "password" : "!codeit05"
+  "email" : "codeit04@codeit.com",
+  "password" : "!codeit04"
 }
 
 ###
-POST http://localhost:3000/auth/sign-out
+POST https://one-favoritephoto-1-be.onrender.com/auth/sign-out
+Content-Type : application/json
+Cookie: connect.sid=YOUR_SESSION_COOKIE_HERE

--- a/http/users.http
+++ b/http/users.http
@@ -64,7 +64,7 @@ Content-Type : application/json
 Cookie: connect.sid=YOUR_SESSION_COOKIE_HERE
 
 ###
-GET http://localhost:3000/users/my-cards/exchange
+GET http://localhost:3000/users/exchange
 Content-Type : application/json
 Cookie: connect.sid=YOUR_SESSION_COOKIE_HERE
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "type": "module",
   "scripts": {
-    "start": "node app.js",
-    "dev": "nodemon app.js"
+    "start": "set NODE_ENV=production && node app.js",
+    "dev": "set NODE_ENV=local && nodemon app.js"
   }
 }

--- a/src/controllers/users-controller.js
+++ b/src/controllers/users-controller.js
@@ -70,14 +70,16 @@ async function getMyRequestList(req, res, next) {
   }
 }
 
-// async function getMyProfile(req, res, next){
-//   try{
-//     const result = ;
-//     return res.status(200).send(result);
-//   }catch(err){
-//     return next(err);
-//   }
-// }
+async function getMyInfo(req, res, next) {
+  try {
+    const userId = req.session.userId;
+    const result = await userService.getMyInfo(userId);
+
+    return res.status(200).send(result);
+  } catch (err) {
+    return next(err);
+  }
+}
 
 // async function checkValidateEmail(req, res, next){
 //   try{
@@ -103,4 +105,5 @@ export default {
   createMyCard,
   getMyShopList,
   getMyRequestList,
+  getMyInfo,
 };

--- a/src/repositories/exchange-repository.js
+++ b/src/repositories/exchange-repository.js
@@ -67,7 +67,7 @@ async function findFirstData({ where, select }) {
 }
 
 async function findUniqueOrThrowtData({ where, select }) {
-  return await prisma.exchange.findFirst({ where, select });
+  return await prisma.exchange.findFirstOrThrow({ where, select });
 }
 
 async function conutData(where) {

--- a/src/repositories/ownRepository.js
+++ b/src/repositories/ownRepository.js
@@ -136,7 +136,7 @@ async function findFirstData({ where, select }) {
 }
 
 async function findUniqueOrThrowtData({ where, select }) {
-  return await prisma.own.findFirst({ where, select });
+  return await prisma.own.findFirstOrThrow({ where, select });
 }
 
 async function conutData(where) {

--- a/src/repositories/user-repository.js
+++ b/src/repositories/user-repository.js
@@ -47,10 +47,56 @@ async function decreaseUserPoint({ id, lostPoint }) {
   });
 }
 
+async function createData({ data, select }) {
+  return await prisma.user.create({ data, select });
+}
+
+async function findFirstData({ where, select }) {
+  return await prisma.user.findFirst({ where, select });
+}
+
+async function findUniqueOrThrowtData({ where, select }) {
+  return await prisma.user.findFirstOrThrow({ where, select });
+}
+
+async function conutData(where) {
+  return await prisma.user.count({ where });
+}
+
+async function findManyData({ where, select }) {
+  return await prisma.user.findMany({ where, select });
+}
+
+async function findManyByPaginationData({
+  orderBy,
+  skip,
+  take,
+  where,
+  select,
+}) {
+  return await prisma.user.findMany({ orderBy, skip, take, where, select });
+}
+
+async function updateData({ where, data, select }) {
+  return await prisma.user.update({ where, data, select });
+}
+
+async function deleteData(where) {
+  await prisma.user.delete({ where });
+}
+
 export default {
   createUser,
   getUserInfoByUserId,
   getUserInfoPasswordByEmail,
   increaseUserPoint,
   decreaseUserPoint,
+  createData,
+  findFirstData,
+  findUniqueOrThrowtData,
+  conutData,
+  findManyData,
+  findManyByPaginationData,
+  updateData,
+  deleteData,
 };

--- a/src/routes/user-router.js
+++ b/src/routes/user-router.js
@@ -19,9 +19,7 @@ userRouter
   .post("/my-cards", authMiddleware, userController.createMyCard)
   .get("/exchange", authMiddleware, userController.getMyRequestList)
   .get("/shop", authMiddleware, userController.getMyShopList)
-  .get("/profile", authMiddleware, (req, res, next) => {
-    // 내 프로필 조회
-  })
+  .get("/my-info", authMiddleware, userController.getMyInfo)
   .get("/check-email", (req, res, next) => {
     // 이메일 중복 확인 (리턴 방식/데이터 죠율 필요)
   })

--- a/src/routes/user-router.js
+++ b/src/routes/user-router.js
@@ -19,7 +19,7 @@ userRouter
   .post("/my-cards", authMiddleware, userController.createMyCard)
   .get("/exchange", authMiddleware, userController.getMyRequestList)
   .get("/shop", authMiddleware, userController.getMyShopList)
-  .get("/profile", (req, res, next) => {
+  .get("/profile", authMiddleware, (req, res, next) => {
     // 내 프로필 조회
   })
   .get("/check-email", (req, res, next) => {

--- a/src/services/user-service.js
+++ b/src/services/user-service.js
@@ -16,6 +16,7 @@ import {
   createGenreGradeKeywordWhere,
 } from "../utils/query-util.js";
 import userRepository from "../repositories/user-repository.js";
+import { userSelect } from "../repositories/selects/user-select.js";
 import { exchangeCardShopSelect } from "../repositories/selects/exchange-select.js";
 
 async function getMyCardList({ userId, query }) {
@@ -102,6 +103,12 @@ async function getUserInfoByUserId(id) {
   return await userRepository.getUserInfoByUserId(id);
 }
 
+async function getMyInfo(id) {
+  const where = { id };
+
+  return await userRepository.findFirstData({ where, select: userSelect });
+}
+
 export default {
   getMyCardList,
   getMyCard,
@@ -109,4 +116,5 @@ export default {
   getMyShopList,
   getMyRequestList,
   getUserInfoByUserId,
+  getMyInfo,
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

> 페이지 이동 후 세션 정보 유지 안됨
> 사용자 정보 조회 API 추가 

## 📝작업 내용

> 개발 환경 / 배포 환경에서 다르게 세션 설정되도록 로직 수정
> FE 개발 환경 + BE 배포 환경 연결 과정에서 세션이 유지가 안되는 현상을 해결하기 위해 express-session 설정 수정
> GET /users/my-info API 추가

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/f244f721-c064-4e11-ada4-e70c668022e0)

## 💬리뷰 요구사항(선택)

> BE 개발 환경에서 .http 테스트
> BE 배포 환경에서 .http 테스트
> FE 개발 환경에서 BE 배포 환경 테스트
> 위의 테스트를 진행하였고, 위의 테스트 중 가능한 테스트를 진행해서 정상이면 merge 진행해주시면 됩니다
