### PR TITLE
[송영섭] 상점 잔여량 + 보유 중인 카드 조회 API 추가  

### DIFF
--- a/docs/api_shop.md
+++ b/docs/api_shop.md
@@ -5,8 +5,6 @@
 - description : 포토 카드 판매 등록
 - path : /shop
 - method : POST
-- headers
-  - Authorization : Bearer {accessToken}
 - body
   - cardId: 카드ID
   - salesQuantity: 판매수량
@@ -17,8 +15,6 @@
 
 ### req example
 
-- headers
-  - Authorization : Bearer {accessToken}
 - body : {
   cardId: "8f1e54c6-f439-4b3b-b710-296bd27cdd72",
   salesQuantity: 3,
@@ -149,15 +145,11 @@
 - description : 상점 상세 조회
 - path : /shop/:shopId
 - method : GET
-- header
-  - Authorization : Bearer {accessToken}
 - params
   - shopId : 상점ID
 
 ### req example
 
-- header
-  - Authorization : Bearer {accessToken}
 - params
   - adfc1706-a7f6-4c6e-a006-1733a854afbb
 
@@ -267,8 +259,6 @@
 - description : 내가 판매 등록한 포토 카드 수정
 - path : /shop/:shopId
 - method : PATCH
-- - header
-    - Authorization : Bearer {accessToken}
 - params
   - shopId: 상점 ID
 - body
@@ -280,8 +270,6 @@
 
 ### req example
 
-- header
-  - Authorization : Bearer {accessToken}
 - params
   - adfc1706-a7f6-4c6e-a006-1733a854afbb
 - body : {
@@ -384,8 +372,6 @@
 - description: 포토카드 구매
 - path: /shop/:shopId/purchase
 - method: POST
-- header
-    - Authorization : Bearer {accessToken}
 - params
     - shopId: 상점ID
 - body
@@ -413,4 +399,29 @@
 	grade: 5,
 	name: "우리집 앞마당",
 	purchaseQuantity: 2
+}
+
+## GET /shop/:shopId/quantity
+
+### req template
+- description: 상점 잔여량 + 보유 중인 카드 조회
+- path: /shop/:shopId/quantity
+- method: GET
+- params
+    - shopId: 상점ID
+
+### req example
+
+- params
+  - adfc1706-a7f6-4c6e-a006-1733a854afbb
+
+### res template
+
+- data
+    - totalQuantity: 상점 잔여량 + 보유 중인 카드
+
+### res example
+
+- data : {
+	totalQuantity: 10,
 }

--- a/http/auth.http
+++ b/http/auth.http
@@ -13,7 +13,7 @@ POST http://localhost:3000/auth/sign-in
 Content-Type : application/json
 
 {
-    "email" : "songyoungsub@codeit.com",
+    "email" : "codeit01@codeit.com",
     "password" : "!codeit01"
 }
 
@@ -39,7 +39,7 @@ Content-Type : application/json
 
 {
     "email" : "songyoungsub@codeit.com",
-    "password" : "!codeit06"
+    "password" : "!codeit0"
 }
 
 ###

--- a/http/exchange.http
+++ b/http/exchange.http
@@ -71,7 +71,13 @@ POST http://localhost:3000/auth/sign-out
 
 
 ###
-POST http://localhost:3000/exchange/87065494-38be-48b6-8efd-1d7b695e9cd9/accept
+POST http://localhost:3000/exchange/d4ba8021-fb6c-4862-a53e-0bb01ab12003/accept
+Cookie: connect.sid=YOUR_SESSION_COOKIE_HERE
 
 ###
-POST http://localhost:3000/exchange/d3291be5-2080-4b6c-82c8-dc101dbd9175/refuse
+POST http://localhost:3000/exchange/d4ba8021-fb6c-4862-a53e-0bb01ab12003/refuse
+Cookie: connect.sid=YOUR_SESSION_COOKIE_HERE
+
+###
+DELETE http://localhost:3000/exchange/d4ba8021-fb6c-4862-a53e-0bb01ab12003
+Cookie: connect.sid=YOUR_SESSION_COOKIE_HERE

--- a/http/shop.http
+++ b/http/shop.http
@@ -42,6 +42,9 @@ Cookie: connect.sid=YOUR_SESSION_COOKIE_HERE
 }
 
 ###
+GET http://localhost:3000/shop/cbb24524-6818-4b46-8afb-00dd26f379ba/quantity
+
+###
 PATCH  https://one-favoritephoto-1-be.onrender.com/shop/8d444419-89d6-46b7-987c-89fc12f231aa
 Content-Type: application/json
 Cookie: connect.sid=YOUR_SESSION_COOKIE_HERE

--- a/src/controllers/exchange-controller.js
+++ b/src/controllers/exchange-controller.js
@@ -11,9 +11,9 @@ async function acceptByExchange(req, res, next) {
   res.send(acceptExchange);
 }
 
-async function refuseByExchange(req, res, next) {
+async function refuseOrCancelExchange(req, res, next) {
   const { exchangeId } = req.params;
-  const refuseExchange = await exchangeService.refuseByExchange(
+  const refuseExchange = await exchangeService.refuseOrCancelExchange(
     exchangeId,
     req.body
   );
@@ -22,5 +22,5 @@ async function refuseByExchange(req, res, next) {
 
 export default {
   acceptByExchange,
-  refuseByExchange,
+  refuseOrCancelExchange,
 };

--- a/src/controllers/exchange-controller.js
+++ b/src/controllers/exchange-controller.js
@@ -12,10 +12,8 @@ async function acceptByExchange(req, res, next) {
 }
 
 async function refuseByExchange(req, res, next) {
-  const userId = req.session.userId;
   const { exchangeId } = req.params;
   const refuseExchange = await exchangeService.refuseByExchange(
-    userId,
     exchangeId,
     req.body
   );

--- a/src/controllers/shop-controller.js
+++ b/src/controllers/shop-controller.js
@@ -98,6 +98,16 @@ async function createExchange(req, res, next) {
   }
 }
 
+async function calculateTotalQuantity(req, res, next) {
+  const userId = req.session.userId;
+  const shopData = req.body.shopData;
+  console.log(1)
+
+  const result = await shopService.calculateTotalQuantity(userId, shopData);
+
+  res.send(result);
+}
+
 export default {
   createShop,
   getShopList,
@@ -106,4 +116,5 @@ export default {
   purchaseController,
   deleteShop,
   createExchange,
+  calculateTotalQuantity
 };

--- a/src/middlewares/validateData.js
+++ b/src/middlewares/validateData.js
@@ -277,7 +277,40 @@ export async function validateExchangeConditions(req, res, next) {
   next();
 }
 
+export async function validateExchangeCreator(req, res, next) {
+  const { exchangeId } = req.params;
+  const userId = req.session.userId;
 
-export async function name(params) {
-  
+  // exchange 테이블이 존재하는지 확인
+  const exchange = await exchangeRepository.findUniqueOrThrowtData({
+    where: {
+      id: exchangeId,
+    },
+    select: exchangeCardShopAndUserSelect,
+  });
+
+  const exchangeCardId = exchange.Card.id;
+  const shopId = exchange.shopId;
+  const buyerId = exchange.userId;
+
+  // 교환 희망자인지 확인
+  const exchangeCreator = await exchangeRepository.findFirstData({
+    where: {
+      userId,
+      id: exchangeId,
+    },
+  });
+
+  if (exchangeCreator === null || exchangeCreator === undefined) {
+    const error = new Error("You cannot exchange with a request you created.");
+    error.code = 400;
+    next(error);
+  }
+
+  req.body.exchangeData = exchange;
+  req.body.exchangeCardId = exchangeCardId;
+  req.body.shopId = shopId;
+  req.body.buyerId = buyerId;
+
+  next();
 }

--- a/src/middlewares/validateData.js
+++ b/src/middlewares/validateData.js
@@ -8,6 +8,7 @@ import ownRepository from "../repositories/ownRepository.js";
 import exchangeRepository from "../repositories/exchange-repository.js";
 import shopRepository from "../repositories/shopRepository.js";
 import { exchangeCardShopAndUserSelect } from "../repositories/selects/exchange-select.js";
+import { shopDetailSelect } from "../repositories/selects/shopSelect.js";
 
 export async function validateCreateShopData(req, res, next) {
   const userId = req.session.userId;
@@ -244,6 +245,7 @@ export async function validateExchangeConditions(req, res, next) {
   // 품절인지 확인
   const shop = await shopRepository.findUniqueOrThrowtData({
     where: { id: shopId },
+    select: shopDetailSelect,
   });
 
   if (shop.remainingQuantity === 0) {
@@ -270,6 +272,7 @@ export async function validateExchangeConditions(req, res, next) {
     },
   });
 
+  req.body.shopDetailData = shop;
   req.body.shopCardId = shopCardId;
   req.body.hasSellerExchangeCard = hasSellerExchangeCard;
   req.body.hasBuyershopCard = hasBuyershopCard;

--- a/src/middlewares/validateData.js
+++ b/src/middlewares/validateData.js
@@ -317,3 +317,25 @@ export async function validateExchangeCreator(req, res, next) {
 
   next();
 }
+
+export async function checkShopCreator(req, res, next) {
+  const { shopId } = req.params;
+  const userId = req.session.userId;
+
+  const isOwner = await shopRepository.findFirstData({
+    where: {
+      userId,
+      id: shopId,
+    },
+  });
+
+  if (isOwner === null || isOwner === undefined) {
+    const error = new Error("You cannot purchase your own product.");
+    error.code = 400;
+    return next(error);
+  }
+
+  req.body.shopData = isOwner;
+
+  next()
+}

--- a/src/repositories/selects/shopSelect.js
+++ b/src/repositories/selects/shopSelect.js
@@ -1,5 +1,8 @@
 import { cardDetailSelect, cardSelect } from "./card-select.js";
-import { exchangeCardInfo, exchangeCardShopAndUserSelect } from "./exchange-select.js";
+import {
+  exchangeCardInfo,
+  exchangeCardShopAndUserSelect,
+} from "./exchange-select.js";
 
 export const shopSelect = {
   id: true,

--- a/src/routes/exchange-route.js
+++ b/src/routes/exchange-route.js
@@ -18,10 +18,10 @@ exchangeRouter
 
 exchangeRouter
   .route("/:exchangeId/refuse")
-  .post(validateExchangeAndOwner, exchangeController.refuseByExchange);
+  .post(validateExchangeAndOwner, exchangeController.refuseOrCancelExchange);
 
 exchangeRouter
   .route("/:exchangeId")
-  .delete(validateExchangeCreator, exchangeController.refuseByExchange);
-  
+  .delete(validateExchangeCreator, exchangeController.refuseOrCancelExchange);
+
 export default exchangeRouter;

--- a/src/routes/exchange-route.js
+++ b/src/routes/exchange-route.js
@@ -2,6 +2,7 @@ import express from "express";
 import {
   validateExchangeAndOwner,
   validateExchangeConditions,
+  validateExchangeCreator,
 } from "../middlewares/validateData.js";
 import exchangeController from "../controllers/exchange-controller.js";
 
@@ -19,4 +20,8 @@ exchangeRouter
   .route("/:exchangeId/refuse")
   .post(validateExchangeAndOwner, exchangeController.refuseByExchange);
 
+exchangeRouter
+  .route("/:exchangeId")
+  .delete(validateExchangeCreator, exchangeController.refuseByExchange);
+  
 export default exchangeRouter;

--- a/src/routes/shop-router.js
+++ b/src/routes/shop-router.js
@@ -1,6 +1,7 @@
 import express from "express";
 import shopController from "../controllers/shop-controller.js";
 import {
+  checkShopCreator,
   validateCreateShopData,
   validatePurchaseConditions,
   validateUpdaeShopData,
@@ -41,6 +42,14 @@ shopRouter
     authMiddleware,
     validatePurchaseConditions,
     shopController.purchaseController
+  );
+
+shopRouter
+  .route("/:shopId/quantity")
+  .get(
+    authMiddleware,
+    checkShopCreator,
+    shopController.calculateTotalQuantity
   );
 
 export default shopRouter;

--- a/src/services/exchange-service.js
+++ b/src/services/exchange-service.js
@@ -7,6 +7,7 @@ import { exchangeMapper } from "../controllers/mappers/exchange-mapper.js";
 
 import { EXCHANGE_VOLUME } from "../constants/exchange.js";
 import shopRepository from "../repositories/shopRepository.js";
+import { exchangeDelete } from "../utils/sellout-util.js";
 
 async function checkExchangeByUser(userId, shopId) {
   const filter = {
@@ -56,6 +57,7 @@ async function acceptByExchange(userId, exchangeId, reqBody) {
     shopId,
     exchangeCardId,
     buyerId,
+    shopDetailData,
     shopCardId,
     hasSellerExchangeCard,
     hasBuyershopCard,
@@ -120,6 +122,11 @@ async function acceptByExchange(userId, exchangeId, reqBody) {
       const delteeExchange = await exchangeRepository.deleteData({
         id: exchangeId,
       });
+
+      // 매진 시 관련 exchange 삭제
+      if (shopDetailData.remainingQuantity === 1) {
+        await exchangeDelete(shopDetailData);
+      }
 
       const responseMappeing = exchangeMapper(exchangeData);
 

--- a/src/services/exchange-service.js
+++ b/src/services/exchange-service.js
@@ -135,7 +135,7 @@ async function acceptByExchange(userId, exchangeId, reqBody) {
   });
 }
 
-async function refuseByExchange(userId, exchangeId, reqBody) {
+async function refuseByExchange(exchangeId, reqBody) {
   const { exchangeData, exchangeCardId, buyerId } = reqBody;
 
   return await prisma.$transaction(async () => {

--- a/src/services/exchange-service.js
+++ b/src/services/exchange-service.js
@@ -135,7 +135,7 @@ async function acceptByExchange(userId, exchangeId, reqBody) {
   });
 }
 
-async function refuseByExchange(exchangeId, reqBody) {
+async function refuseOrCancelExchange(exchangeId, reqBody) {
   const { exchangeData, exchangeCardId, buyerId } = reqBody;
 
   return await prisma.$transaction(async () => {
@@ -176,5 +176,5 @@ export default {
   checkExchangeByUser,
   createExchange,
   acceptByExchange,
-  refuseByExchange,
+  refuseOrCancelExchange,
 };

--- a/src/services/shopService.js
+++ b/src/services/shopService.js
@@ -10,6 +10,7 @@ import {
   myCardMapper,
 } from "../controllers/mappers/card-mapper.js";
 import { ownCardListSelect } from "../repositories/selects/own-select.js";
+import { exchangeDelete } from "../utils/sellout-util.js";
 
 async function createShop(createData) {
   const { own, ...rest } = createData;
@@ -220,52 +221,7 @@ async function purchaseService(id, userId, purchaseData) {
 
       // 매진 시 교환 신청 삭제
       if (updatedShopQuantity === 0) {
-        const exchangesCardInfo = shopDetailData.Exchanges;
-        const exchangeDelete = await Promise.all(
-          exchangesCardInfo.map(async (exchangeInfo) => {
-            const userId = exchangeInfo.userId;
-            const cardId = exchangeInfo.Card.id;
-            console.log(userId)
-
-            const updateWhere = {
-              userId_cardId: {
-                userId,
-                cardId,
-              },
-            };
-            const updateData = {
-              quantity: {
-                increment: 1,
-              },
-            };
-            const createData = {
-              userId,
-              cardId,
-              quantity: 1,
-            };
-            const own = await ownRepository.findFirstData({
-              where: {
-                userId,
-                cardId,
-              },
-            });
-
-            if (own === null || own === undefined) {
-              const w = await ownRepository.createData({ data: createData });
-              console.log(w);
-            } else {
-              const q = await ownRepository.updateData({
-                where: updateWhere,
-                data: updateData,
-              });
-              console.log(q);
-            }
-
-          })
-        );
-        await exchangeRepository.deleteManyData({
-          shopId: shopDetailData.id,
-        });
+        await exchangeDelete(shopDetailData);
       }
 
       // 구매 이력 추가

--- a/src/services/shopService.js
+++ b/src/services/shopService.js
@@ -285,6 +285,18 @@ async function deleteShop({ userId, shopId }) {
   });
 }
 
+async function calculateTotalQuantity(userId, shopData) {
+  const own = await ownRepository.findFirstData({
+    where: {
+      userId,
+      cardId: shopData.cardId,
+    },
+  });
+  const userStock = own ? own.quantity : 0;
+  const totalQuantity = userStock + shopData.remainingQuantity;
+  return { totalQuantity };
+}
+
 export default {
   createShop,
   getShopListByQuery,
@@ -294,4 +306,5 @@ export default {
   updateShop,
   purchaseService,
   deleteShop,
+  calculateTotalQuantity,
 };

--- a/src/utils/sellout-util.js
+++ b/src/utils/sellout-util.js
@@ -1,6 +1,6 @@
-export async function exchangeDelete(shopDetailData) {
+export async function exchangeDelete(shopDetailDataWithExchange) {
 
-  const exchangesCardInfo = shopDetailData.Exchanges;
+  const exchangesCardInfo = shopDetailDataWithExchange.Exchanges;
   const exchangeDeleteData = await Promise.all(
     exchangesCardInfo.map(async (exchangeInfo) => {
       const userId = exchangeInfo.userId;
@@ -40,6 +40,6 @@ export async function exchangeDelete(shopDetailData) {
     })
   );
   await exchangeRepository.deleteManyData({
-    shopId: shopDetailData.id,
+    shopId: shopDetailDataWithExchange.id,
   });
 }

--- a/src/utils/sellout-util.js
+++ b/src/utils/sellout-util.js
@@ -1,0 +1,45 @@
+export async function exchangeDelete(shopDetailData) {
+
+  const exchangesCardInfo = shopDetailData.Exchanges;
+  const exchangeDeleteData = await Promise.all(
+    exchangesCardInfo.map(async (exchangeInfo) => {
+      const userId = exchangeInfo.userId;
+      const cardId = exchangeInfo.Card.id;
+
+      const own = await ownRepository.findFirstData({
+        where: {
+          userId,
+          cardId,
+        },
+      });
+
+      if (own === null || own === undefined) {
+        const createData = {
+          userId,
+          cardId,
+          quantity: 1,
+        };
+        const result = await ownRepository.createData({ data: createData });
+      } else {
+        const updateWhere = {
+          userId_cardId: {
+            userId,
+            cardId,
+          },
+        };
+        const updateData = {
+          quantity: {
+            increment: 1,
+          },
+        };
+        const result = await ownRepository.updateData({
+          where: updateWhere,
+          data: updateData,
+        });
+      }
+    })
+  );
+  await exchangeRepository.deleteManyData({
+    shopId: shopDetailData.id,
+  });
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> 상점 잔여량 + 보유 중인 카드 조회 AP
> 포토카드 교환 취소 API 

## 📝작업 내용

> 상점 잔여량 + 보유 중인 카드 조회 API 추가  
> 포토카드 교환 취소 API 
> 피드벡에 따라 코드 수정

### 스크린샷 (선택)
![스크린샷 2024-10-22 170914](https://github.com/user-attachments/assets/5d1d9f8b-1f58-453b-ab7c-ce9927cb19a5)
![스크린샷 2024-10-22 170901](https://github.com/user-attachments/assets/a12356eb-5100-4aa8-8bc5-d41f577aa046)
![스크린샷 2024-10-22 170932](https://github.com/user-attachments/assets/28f64cfa-095b-4371-997b-ab59a6ea1c12)


## 💬리뷰 요구사항(선택)
