### PR TITLE
[이진우] 연속 로그인 에러 수정 & auth 관련 함수 정리 

### DIFF
--- a/src/controllers/auth-controller.js
+++ b/src/controllers/auth-controller.js
@@ -38,10 +38,8 @@ async function signOut(req, res, next) {
   try {
     const sessionId = req.session.id;
 
-    await authService.deleteSession(sessionId);
+    await authService.signOut(sessionId);
     req.session.destroy();
-
-    await authService.signOut();
 
     return res.status(200).send();
   } catch (err) {

--- a/src/controllers/auth-controller.js
+++ b/src/controllers/auth-controller.js
@@ -15,20 +15,18 @@ async function signUp(req, res, next) {
 async function signIn(req, res, next) {
   try {
     const { email, password } = req.body;
-    const userInfo = await authService.signIn({ email, password });
+
+    const { userInfo, session } = await authService.signIn({
+      email,
+      password,
+      session: req.session,
+    });
 
     if (!userInfo) {
-      return next(CustomError(40098));
+      return CustomError(40098);
     }
 
-    req.session.userId = userInfo.id;
-    const session = {
-      sessionId: req.session.id,
-      userId: req.session.userId,
-      sessionData: req.session,
-    };
-
-    await authService.createSession(session);
+    req.session = session;
 
     return res.status(200).send(userInfo);
   } catch (err) {

--- a/src/repositories/session-repository.js
+++ b/src/repositories/session-repository.js
@@ -1,15 +1,6 @@
 import prisma from "./prisma.js";
 import { sessionSelect } from "../services/selects/session-select.js";
 
-async function createSession({ sessionId, userId, expires, data }) {
-  const jsonData = JSON.stringify(data);
-
-  return await prisma.session.create({
-    data: { id: sessionId, userId, expires, data: jsonData },
-    select: sessionSelect,
-  });
-}
-
 async function findSession(sessionId) {
   return await prisma.session.findUniqueOrThrow({
     where: { id: sessionId },
@@ -42,7 +33,6 @@ async function deleteManyData(where) {
 }
 
 export default {
-  createSession,
   findSession,
   deleteSession,
   createData,

--- a/src/repositories/session-repository.js
+++ b/src/repositories/session-repository.js
@@ -1,16 +1,4 @@
 import prisma from "./prisma.js";
-import { sessionSelect } from "../services/selects/session-select.js";
-
-async function findSession(sessionId) {
-  return await prisma.session.findUniqueOrThrow({
-    where: { id: sessionId },
-    select: sessionSelect,
-  });
-}
-
-async function deleteSession(sessionId) {
-  return await prisma.session.delete({ where: { id: sessionId } });
-}
 
 async function createData({ data, select }) {
   return await prisma.session.create({ data, select });
@@ -33,8 +21,6 @@ async function deleteManyData(where) {
 }
 
 export default {
-  findSession,
-  deleteSession,
   createData,
   upsertData,
   findFirstData,

--- a/src/repositories/session-repository.js
+++ b/src/repositories/session-repository.js
@@ -21,4 +21,33 @@ async function deleteSession(sessionId) {
   return await prisma.session.delete({ where: { id: sessionId } });
 }
 
-export default { createSession, findSession, deleteSession };
+async function createData({ data, select }) {
+  return await prisma.session.create({ data, select });
+}
+
+async function upsertData({ where, update, create, select }) {
+  return await prisma.session.upsert({ where, update, create, select });
+}
+
+async function findFirstData({ where, select }) {
+  return await prisma.session.findFirst({ where, select });
+}
+
+async function deleteData(where) {
+  await prisma.session.delete({ where });
+}
+
+async function deleteManyData(where) {
+  await prisma.session.deleteMany({ where });
+}
+
+export default {
+  createSession,
+  findSession,
+  deleteSession,
+  createData,
+  upsertData,
+  findFirstData,
+  deleteData,
+  deleteManyData,
+};

--- a/src/repositories/user-repository.js
+++ b/src/repositories/user-repository.js
@@ -53,6 +53,10 @@ async function createData({ data, select }) {
   return await prisma.user.create({ data, select });
 }
 
+async function upsertData({ where, update, create, select }) {
+  return await prisma.user.upsert({ where, update, create, select });
+}
+
 async function findFirstData({ where, select }) {
   return await prisma.user.findFirst({ where, select });
 }
@@ -87,6 +91,10 @@ async function deleteData(where) {
   await prisma.user.delete({ where });
 }
 
+async function deleteManyData(where) {
+  await prisma.user.deleteMany({ where });
+}
+
 export default {
   createUser,
   getUserInfoByUserId,
@@ -94,6 +102,7 @@ export default {
   increaseUserPoint,
   decreaseUserPoint,
   createData,
+  upsertData,
   findFirstData,
   findUniqueOrThrowtData,
   countData,
@@ -101,4 +110,5 @@ export default {
   findManyByPaginationData,
   updateData,
   deleteData,
+  deleteManyData,
 };

--- a/src/services/auth-service.js
+++ b/src/services/auth-service.js
@@ -9,10 +9,6 @@ import {
 
 import { EXPIRE_TIME } from "../constants/session.js";
 
-async function deleteSession(sessionId) {
-  await sessionRepository.deleteSession(sessionId);
-}
-
 async function signUp({ email, password, nickname }) {
   const encryptedPassword = await createHashedPassword(password);
 
@@ -67,6 +63,10 @@ async function signIn({ email, password, session }) {
   });
 }
 
-async function signOut() {}
+async function signOut(sessionId) {
+  const where = { id: sessionId };
 
-export default { deleteSession, signUp, signIn, signOut };
+  await sessionRepository.deleteData(where);
+}
+
+export default { signUp, signIn, signOut };

--- a/src/services/auth-service.js
+++ b/src/services/auth-service.js
@@ -9,18 +9,6 @@ import {
 
 import { EXPIRE_TIME } from "../constants/session.js";
 
-async function createSession({ sessionId, userId, sessionData }) {
-  const now = new Date();
-  const expires = new Date(now.getTime() + EXPIRE_TIME);
-
-  const sessionInfo = await sessionRepository.createSession({
-    sessionId,
-    userId,
-    expires,
-    data: sessionData,
-  });
-}
-
 async function deleteSession(sessionId) {
   await sessionRepository.deleteSession(sessionId);
 }
@@ -81,4 +69,4 @@ async function signIn({ email, password, session }) {
 
 async function signOut() {}
 
-export default { createSession, deleteSession, signUp, signIn, signOut };
+export default { deleteSession, signUp, signIn, signOut };

--- a/src/services/auth-service.js
+++ b/src/services/auth-service.js
@@ -13,7 +13,7 @@ async function createSession({ sessionId, userId, sessionData }) {
   const now = new Date();
   const expires = new Date(now.getTime() + EXPIRE_TIME);
 
-  const session = await sessionRepository.createSession({
+  const sessionInfo = await sessionRepository.createSession({
     sessionId,
     userId,
     expires,
@@ -41,24 +41,42 @@ async function signUp({ email, password, nickname }) {
   });
 }
 
-async function signIn({ email, password }) {
-  const { encryptedPassword, ...rest } =
-    await userRepository.getUserInfoPasswordByEmail(email);
+async function signIn({ email, password, session }) {
+  return prisma.$transaction(async () => {
+    const { encryptedPassword, ...rest } =
+      await userRepository.getUserInfoPasswordByEmail(email);
 
-  if (!encryptedPassword) {
-    return null;
-  }
+    if (!encryptedPassword) {
+      return null;
+    }
 
-  const isCorrect = await comparePassword({
-    passwordInput: password,
-    encryptedPassword,
+    const isCorrect = await comparePassword({
+      passwordInput: password,
+      encryptedPassword,
+    });
+
+    if (!isCorrect) {
+      return null;
+    }
+
+    const userId = rest.id;
+    session.userId = userId;
+    const now = new Date();
+    const expires = new Date(now.getTime() + EXPIRE_TIME);
+    const data = JSON.stringify(session);
+
+    const upsertWhere = { id: session.id };
+    const upsertCreate = { id: session.id, userId, expires, data };
+    const upsertUpdate = { userId, expires, data };
+
+    await sessionRepository.upsertData({
+      where: upsertWhere,
+      create: upsertCreate,
+      update: upsertUpdate,
+    });
+
+    return { userInfo: rest, session };
   });
-
-  if (!isCorrect) {
-    return null;
-  }
-
-  return rest;
 }
 
 async function signOut() {}

--- a/src/services/selects/session-select.js
+++ b/src/services/selects/session-select.js
@@ -1,6 +1,9 @@
+// 테스트 용
 export const sessionSelect = {
   id: true,
   userId: true,
   expires: true,
   data: true,
+  createdAt: true,
+  updatedAt: true,
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

> 연속으로 로그인 시도 시 DB에 저장하는 세션 아이디 충돌 이슈
> 함수 정리

## 📝작업 내용

> 로그인 과정에서 create가 아닌 upsert를 사용하여 충돌 이슈 해결
> auth API 관련 로직 함수 정

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/370e970f-ed0e-4f36-9e25-1ec4979ba7db)

## 💬리뷰 요구사항(선택)

> 함수 정리한 부분 봐주시면 됩니다
